### PR TITLE
fixed filter_row function

### DIFF
--- a/liiatools/datasets/annex_a/lds_annexa_clean/file_creator.py
+++ b/liiatools/datasets/annex_a/lds_annexa_clean/file_creator.py
@@ -72,13 +72,13 @@ def filter_rows(event):
         "List 11": "Date enquiry received",
     }
 
-    if (
-        event.sheet_name in event_types
-        and event.row[event_types[event.sheet_name]]
-    ):
-        yield event.from_event(event, filter=0)
+    if event.sheet_name in event_types:
+        if event.row[event_types[event.sheet_name]]:
+            yield event.from_event(event, filter=0)
+        else:
+            yield event.from_event(event, filter=1)
     else:
-        yield event.from_event(event, filter=1)
+        yield event.from_event(event, filter=0)
 
 
 class TableEvent(events.ParseEvent):

--- a/tests/annex_a/test_file_creator.py
+++ b/tests/annex_a/test_file_creator.py
@@ -56,9 +56,15 @@ def test_filter_rows():
             file_creator.RowEvent(sheet_name="List 1", row={"Date of Contact": "some value"}),
             file_creator.RowEvent(sheet_name="List 1", row={"Date of Contact": ""}),
             file_creator.RowEvent(sheet_name="List 1", row={"Date of Contact": None}),
+            file_creator.RowEvent(sheet_name="List 2", row={"Date of Contact": "some value"}),
+            file_creator.RowEvent(sheet_name="List 2", row={"Date of Contact": ""}),
+            file_creator.RowEvent(sheet_name="List 2", row={"Date of Contact": None}),
         ]
     )
     stream = list(stream)
     assert stream[0].filter == 0
     assert stream[1].filter == 1
     assert stream[2].filter == 1
+    assert stream[3].filter == 0
+    assert stream[4].filter == 0
+    assert stream[5].filter == 0


### PR DESCRIPTION
filter_row would assign filter=1 to sheets not included in event_types. This is incorrect as some sheets do not need to be filtered at all