### PR TITLE
Added to 903: allow extra columns in input sheets

### DIFF
--- a/liiatools/datasets/s903/lds_ssda903_clean/configuration.py
+++ b/liiatools/datasets/s903/lds_ssda903_clean/configuration.py
@@ -29,8 +29,8 @@ def add_table_name(event):
     :return: An updated list of event objects
     """
     for table_name, expected_columns in column_names.items():
-        if set(event.headers) == set(expected_columns):
-            return event.from_event(event, table_name=table_name)
+        if set(expected_columns).issubset(set(event.headers)):
+            return event.from_event(event, expected_columns=expected_columns, table_name=table_name)
     return event
 
 
@@ -67,6 +67,7 @@ def configure_stream(stream, config):
     """
     stream = add_table_name(stream)
     stream = inherit_property(stream, "table_name")
+    stream = inherit_property(stream, "expected_columns")
     stream = match_config_to_cell(stream, config=config["column_map"])
     return stream
 

--- a/liiatools/datasets/s903/lds_ssda903_clean/file_creator.py
+++ b/liiatools/datasets/s903/lds_ssda903_clean/file_creator.py
@@ -26,7 +26,7 @@ def coalesce_row(stream):
         elif isinstance(event, events.EndRow):
             yield RowEvent.from_event(event, row=row)
             row = None
-        elif row is not None and isinstance(event, events.Cell):
+        elif row is not None and isinstance(event, events.Cell) and event.header in set(event.expected_columns):
             row.append(event.cell)
         else:
             yield event
@@ -52,7 +52,7 @@ def create_tables(stream, la_name):
             if match_error or year_error is not None:
                 data = None
             else:
-                data = tablib.Dataset(headers=event.headers + ["LA", "YEAR"])
+                data = tablib.Dataset(headers=event.expected_columns + ["LA", "YEAR"])
         elif isinstance(event, events.EndTable):
             yield event
             yield TableEvent.from_event(event, data=data)

--- a/liiatools/datasets/s903/lds_ssda903_clean/logger.py
+++ b/liiatools/datasets/s903/lds_ssda903_clean/logger.py
@@ -123,6 +123,29 @@ def create_file_match_error(event):
     return event
 
 
+@streamfilter(
+    check=type_check(events.StartTable),
+    fail_function=pass_event,
+    error_function=pass_event,
+)
+def create_extra_column_error(event):
+    """
+    Add a extra_column_error to StartTables that have more columns than the set of expected columns so these can be written to the log.txt
+
+    :param event: A filtered list of event objects of type StartTable
+    :return: An updated list of event objects
+    """
+    extra_columns = [item for item in event.headers if item not in event.expected_columns]
+    if len(extra_columns) == 0:
+        return event
+    else:
+        return event.from_event(
+            event,
+            extra_column_error=f"Additional columns were found in file titled "
+            f"'{event.filename}' than those expected from schema for filetype = {event.table_name}, so these columns have been removed: {extra_columns}",
+        )
+
+
 def save_errors_la(stream, la_log_dir):
     """
     Count the error events and save them as a text file in the Local Authority Logs directory
@@ -180,6 +203,14 @@ def save_errors_la(stream, la_log_dir):
                 ) as f:
                     f.write(match_error)
                     f.write("\n")
+            column_error = getattr(event, "extra_column_error", None)
+            if column_error:
+                with open(
+                    f"{os.path.join(la_log_dir, event.filename)}_error_log_{start_time}.txt",
+                    "a",
+                ) as f:  
+                    f.write(column_error)
+                    f.write("\n")
         yield event
 
 
@@ -194,4 +225,5 @@ def log_errors(stream):
     stream = create_formatting_error_count(stream)
     stream = create_blank_error_count(stream)
     stream = create_file_match_error(stream)
+    stream = create_extra_column_error(stream)
     return stream


### PR DESCRIPTION
Previously, if a 903 input sheet had the correct columns but also had additional columns, the file would not be processed and the LA would get a file match error saying that the columns did not match any of the expected sets of columns for 903 files.

Now, as long as a subset of the input columns matches an expected set of columns, the file will process but will eliminate the extra columns.

The LA gets a new error type in the log called "extra columns error" which tells them that additional columns were found and were removed and gives the names of the columns. #102 

The attached file is what was used to test this functionality.

[SSDA903_2020_episodes_extra.csv](https://github.com/SocialFinanceDigitalLabs/liia-tools/files/9497178/SSDA903_2020_episodes_extra.csv)