### PR TITLE
Sort 903 la files by year before dedup

### DIFF
--- a/liiatools/datasets/s903/lds_ssda903_la_agg/process.py
+++ b/liiatools/datasets/s903/lds_ssda903_la_agg/process.py
@@ -49,10 +49,9 @@ def deduplicate(s903_df, table_name, sort_order, dedup):
     """
     Sorts and removes duplicate records from merged files following schema
     """
-    if table_name in sort_order.keys():
-        s903_df = s903_df.sort_values(
-            sort_order[table_name], ascending=False, ignore_index=True
-        )
+    s903_df = s903_df.sort_values(
+        sort_order[table_name], ascending=False, ignore_index=True
+    )
     if table_name in dedup.keys():
         s903_df = s903_df.drop_duplicates(subset=dedup[table_name], keep="first")
     return s903_df

--- a/liiatools/spec/s903/la-agg.yml
+++ b/liiatools/spec/s903/la-agg.yml
@@ -133,10 +133,27 @@ dates:
 sort_order:
     Header:
         - MC_DOB
+        - YEAR
     Episodes:
         - DEC
+        - YEAR
+    Reviews:
+        - YEAR
     UASC:
         - DUC
+        - YEAR
+    OC2:
+        - YEAR
+    OC3:
+        - YEAR
+    AD1:
+        - YEAR
+    PlacedAdoption:
+        - YEAR
+    PrevPerm:
+        - YEAR
+    Missing:
+        - YEAR
 
 dedup:
     Header:

--- a/tests/s903/test_la_agg.py
+++ b/tests/s903/test_la_agg.py
@@ -23,11 +23,11 @@ def test_deduplicate():
             "Column 3": ["Answer 1", "Answer 2"],
         }
     )
-    sort_order = {"Sorted": ["Column 1"]}
-    table_name_1 = "Not_sorted"
-    table_name_2 = "Sorted"
-    table_name_3 = "Something else"
-    dedup = {"Sorted": ["Column 2"], "Not_sorted": ["Column 2"]}
+    sort_order = {"Table_1": ["Column 2"], "Table_2": ["Column 1"], "Table_3": ["Column 2"]}
+    table_name_1 = "Table_1"
+    table_name_2 = "Table_2"
+    table_name_3 = "Table_3"
+    dedup = {"Table_1": ["Column 2"], "Table_2": ["Column 2"], "Table_3": ["Column 1"]}
     output_df_1 = process.deduplicate(test_df_1, table_name_1, sort_order, dedup)
     assert len(output_df_1) == 1
     assert output_df_1["Column 3"][0] == "Answer 1"


### PR DESCRIPTION
Spotted a potential issue in the code where the data retention policy might clash with the de-duplication functions for the 903. Previously, the de-dup would keep the first version of a set of duplicates that it found. There was nothing guaranteeing that this would be the most recent version of that set (i.e. the one from the most recent year's return). This means that arbitrarily the top row could be from an older return. This means that the data retention process would delete this row earlier than it should do (as a more recent version of the same row was already deleted in the de-dup process).

I've added the functionality to sort each return by YEAR before de-duping. This means that the copy of any set of duplicates that is retained by the dedup function will always be the most recent.

Updated test of this function as well.