### PR TITLE
make year checker more robust

### DIFF
--- a/liiatools/datasets/cin_census/lds_cin_clean/file_creator.py
+++ b/liiatools/datasets/cin_census/lds_cin_clean/file_creator.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import re
 import pandas as pd
 import logging
 
@@ -15,9 +14,8 @@ def convert_to_dataframe(data):
 
 def get_year(input, data, la_log_dir):
     filename = Path(input).stem
-    match = re.search(r"20\d{2}", filename)
     try:
-        year = match.group(0)
+        year = common.check_year(filename)
         data["YEAR"] = year
         return data
     except AttributeError:

--- a/liiatools/datasets/s903/lds_ssda903_clean/configuration.py
+++ b/liiatools/datasets/s903/lds_ssda903_clean/configuration.py
@@ -30,7 +30,9 @@ def add_table_name(event):
     """
     for table_name, expected_columns in column_names.items():
         if set(expected_columns).issubset(set(event.headers)):
-            return event.from_event(event, expected_columns=expected_columns, table_name=table_name)
+            return event.from_event(
+                event, expected_columns=expected_columns, table_name=table_name
+            )
     return event
 
 

--- a/liiatools/datasets/s903/lds_ssda903_clean/file_creator.py
+++ b/liiatools/datasets/s903/lds_ssda903_clean/file_creator.py
@@ -26,7 +26,11 @@ def coalesce_row(stream):
         elif isinstance(event, events.EndRow):
             yield RowEvent.from_event(event, row=row)
             row = None
-        elif row is not None and isinstance(event, events.Cell) and event.header in set(event.expected_columns):
+        elif (
+            row is not None
+            and isinstance(event, events.Cell)
+            and event.header in set(event.expected_columns)
+        ):
             row.append(event.cell)
         else:
             yield event

--- a/liiatools/datasets/s903/lds_ssda903_clean/logger.py
+++ b/liiatools/datasets/s903/lds_ssda903_clean/logger.py
@@ -135,7 +135,9 @@ def create_extra_column_error(event):
     :param event: A filtered list of event objects of type StartTable
     :return: An updated list of event objects
     """
-    extra_columns = [item for item in event.headers if item not in event.expected_columns]
+    extra_columns = [
+        item for item in event.headers if item not in event.expected_columns
+    ]
     if len(extra_columns) == 0:
         return event
     else:
@@ -208,7 +210,7 @@ def save_errors_la(stream, la_log_dir):
                 with open(
                     f"{os.path.join(la_log_dir, event.filename)}_error_log_{start_time}.txt",
                     "a",
-                ) as f:  
+                ) as f:
                     f.write(column_error)
                     f.write("\n")
         yield event

--- a/liiatools/datasets/s903/lds_ssda903_clean/populate.py
+++ b/liiatools/datasets/s903/lds_ssda903_clean/populate.py
@@ -21,8 +21,7 @@ def add_year_column(stream, input, la_log_dir):
         if isinstance(event, events.StartTable):
             try:
                 file_dir = event.filename
-                match = re.search(r"20\d{2}", file_dir)
-                year = match.group(0)
+                year = common.check_year(file_dir)
                 yield event.from_event(event, year=year)
             except AttributeError:
                 common.save_year_error(input, la_log_dir)

--- a/liiatools/datasets/shared_functions/common.py
+++ b/liiatools/datasets/shared_functions/common.py
@@ -94,6 +94,34 @@ def save_year_error(input, la_log_dir):
         )
 
 
+def check_year(string):
+    """
+    Check a string to see if it contains a year, if it does, return that year
+    Expected year formats within string:
+        2022
+        14032021
+        2017-18
+        201819
+
+    :param string: String that probably contains a year
+    :return: Year withing the string
+    """
+    match = re.search(r"(20)\d{2}(.*\d)*", string)
+    try:
+        if len(match.group(2)) == 2:
+            year = match.group(1) + match.group(2)
+            return year
+        if len(match.group(2)) == 3:
+            year = match.group(1) + match.group(2)[1:]
+            return year
+        if len(match.group(2)) == 4:
+            year = match.group(2)
+            return year
+    except TypeError:
+        year = match.group(0)
+        return year
+
+
 def check_file_type(input, file_types, supported_file_types, la_log_dir):
     """
     Check that the correct type of file is being used, e.g. xml. If it is then continue.

--- a/liiatools/datasets/shared_functions/common.py
+++ b/liiatools/datasets/shared_functions/common.py
@@ -94,32 +94,35 @@ def save_year_error(input, la_log_dir):
         )
 
 
-def check_year(string):
+def check_year(filename):
     """
-    Check a string to see if it contains a year, if it does, return that year
+    Check a filename to see if it contains a year, if it does, return that year
     Expected year formats within string:
         2022
         14032021
         2017-18
         201819
 
-    :param string: String that probably contains a year
+    :param filename: Filename that probably contains a year
     :return: Year withing the string
     """
-    match = re.search(r"(20)\d{2}(.*\d)*", string)
-    try:
-        if len(match.group(2)) == 2:
-            year = match.group(1) + match.group(2)
+    match = re.search(r"(20)\d{2}(.*\d)*", filename)
+    if match:
+        try:
+            if len(match.group(2)) == 2:
+                year = match.group(1) + match.group(2)
+                return year
+            if len(match.group(2)) == 3:
+                year = match.group(1) + match.group(2)[1:]
+                return year
+            if len(match.group(2)) == 4:
+                year = match.group(2)
+                return year
+        except TypeError:
+            year = match.group(0)
             return year
-        if len(match.group(2)) == 3:
-            year = match.group(1) + match.group(2)[1:]
-            return year
-        if len(match.group(2)) == 4:
-            year = match.group(2)
-            return year
-    except TypeError:
-        year = match.group(0)
-        return year
+    else:
+        raise AttributeError
 
 
 def check_file_type(input, file_types, supported_file_types, la_log_dir):

--- a/tests/common/test_common.py
+++ b/tests/common/test_common.py
@@ -9,6 +9,7 @@ from liiatools.datasets.shared_functions.converters import (
     to_date,
 )
 import datetime
+import unittest
 
 
 def test_flip_dict():
@@ -51,3 +52,9 @@ def test_check_year():
     assert check_year("file_140032021.csv") == "2021"
     assert check_year("file_2017-18.csv") == "2018"
     assert check_year("file_201819.csv") == "2019"
+
+
+class TestCheckYear(unittest.TestCase):
+    def test_check_year(self):
+        with self.assertRaises(AttributeError):
+            check_year("file_no_year.csv")

--- a/tests/common/test_common.py
+++ b/tests/common/test_common.py
@@ -1,6 +1,7 @@
 from liiatools.datasets.shared_functions.common import (
     check_postcode,
     flip_dict,
+    check_year,
 )
 from liiatools.datasets.shared_functions.converters import (
     to_short_postcode,
@@ -43,3 +44,10 @@ def test_to_date():
         to_date(datetime.datetime(2020, 3, 19)) == datetime.datetime(2020, 3, 19).date()
     )
     assert to_date("15/03/2017") == datetime.datetime(2017, 3, 15).date()
+
+
+def test_check_year():
+    assert check_year("file_2022.csv") == "2022"
+    assert check_year("file_140032021.csv") == "2021"
+    assert check_year("file_2017-18.csv") == "2018"
+    assert check_year("file_201819.csv") == "2019"

--- a/tests/s903/test_populate.py
+++ b/tests/s903/test_populate.py
@@ -1,5 +1,4 @@
 import tempfile as tmp
-import unittest
 
 from liiatools.datasets.s903.lds_ssda903_clean import populate
 
@@ -12,7 +11,49 @@ def test_add_year_column():
 
     stream = populate.add_year_column(
         [
-            events.StartTable(filename="test_file_2022"),
+            events.StartTable(filename="test_file_20082022"),
+            events.EndRow(),
+            events.EndTable(),
+        ],
+        input=input,
+        la_log_dir=la_log_dir,
+    )
+    stream = list(stream)
+    assert stream[0].year == "2022"
+    assert stream[1].year == "2022"
+    assert not hasattr(stream[2], "year")
+
+    stream = populate.add_year_column(
+        [
+            events.StartTable(filename="test_file_2017"),
+            events.EndRow(),
+            events.EndTable(),
+        ],
+        input=input,
+        la_log_dir=la_log_dir,
+    )
+    stream = list(stream)
+    assert stream[0].year == "2017"
+    assert stream[1].year == "2017"
+    assert not hasattr(stream[2], "year")
+
+    stream = populate.add_year_column(
+        [
+            events.StartTable(filename="test_file_2017-18"),
+            events.EndRow(),
+            events.EndTable(),
+        ],
+        input=input,
+        la_log_dir=la_log_dir,
+    )
+    stream = list(stream)
+    assert stream[0].year == "2018"
+    assert stream[1].year == "2018"
+    assert not hasattr(stream[2], "year")
+
+    stream = populate.add_year_column(
+        [
+            events.StartTable(filename="test_file_202122"),
             events.EndRow(),
             events.EndTable(),
         ],


### PR DESCRIPTION
Improve the regex used to find year in filenames. Run python -m black