### PR TITLE
allow script to run with errors in unnecessary <Header> node

### DIFF
--- a/liiatools/datasets/cin_census/lds_cin_clean/logger.py
+++ b/liiatools/datasets/cin_census/lds_cin_clean/logger.py
@@ -47,18 +47,16 @@ def counter(event, counter_check, value_error, structural_error):
     :return: The same filtered list of event objects
     """
     if counter_check(event) and len(event.node) == 0:
-        try:
-            if event.LAchildID is not None:
-                try:
-                    value_error.append(
-                        f"LAchildID: {event.LAchildID}, Node: {event.schema.name}"
-                    )
-                except AttributeError:  # Raised in case there is no event.schema.name
-                    structural_error.append(
-                        f"LAchildID: {event.LAchildID}, Node: {event.tag}"
-                    )
-        except AttributeError:  # In case there are errors in the <Header> node
-            return event
+        if hasattr(event, "LAchildID"):  # In case there are errors in the <Header> node as none of these
+            # will have an LAchildID assigned
+            if hasattr(event.schema, "name"):
+                value_error.append(
+                    f"LAchildID: {event.LAchildID}, Node: {event.schema.name}"
+                )
+            else:
+                structural_error.append(
+                    f"LAchildID: {event.LAchildID}, Node: {event.tag}"
+                )
     return event
 
 

--- a/liiatools/datasets/cin_census/lds_cin_clean/logger.py
+++ b/liiatools/datasets/cin_census/lds_cin_clean/logger.py
@@ -47,15 +47,18 @@ def counter(event, counter_check, value_error, structural_error):
     :return: The same filtered list of event objects
     """
     if counter_check(event) and len(event.node) == 0:
-        if event.LAchildID is not None:
-            try:
-                value_error.append(
-                    f"LAchildID: {event.LAchildID}, Node: {event.schema.name}"
-                )
-            except AttributeError:  # Raised in case there is no event.schema.name
-                structural_error.append(
-                    f"LAchildID: {event.LAchildID}, Node: {event.tag}"
-                )
+        try:
+            if event.LAchildID is not None:
+                try:
+                    value_error.append(
+                        f"LAchildID: {event.LAchildID}, Node: {event.schema.name}"
+                    )
+                except AttributeError:  # Raised in case there is no event.schema.name
+                    structural_error.append(
+                        f"LAchildID: {event.LAchildID}, Node: {event.tag}"
+                    )
+        except AttributeError:  # In case there are errors in the <Header> node
+            return event
     return event
 
 

--- a/liiatools/datasets/cin_census/lds_cin_clean/logger.py
+++ b/liiatools/datasets/cin_census/lds_cin_clean/logger.py
@@ -47,7 +47,9 @@ def counter(event, counter_check, value_error, structural_error):
     :return: The same filtered list of event objects
     """
     if counter_check(event) and len(event.node) == 0:
-        if hasattr(event, "LAchildID"):  # In case there are errors in the <Header> node as none of these
+        if (
+            getattr(event, "LAchildID", None) is not None
+        ):  # In case there are errors in the <Header> node as none of these
             # will have an LAchildID assigned
             if hasattr(event.schema, "name"):
                 value_error.append(

--- a/liiatools/spec/cin_census/cin-2022.xsd
+++ b/liiatools/spec/cin_census/cin-2022.xsd
@@ -5,35 +5,35 @@
 
   <xs:complexType name="messagetype">
     <xs:sequence>
-      <xs:element name="Header" type="headertype" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Header" type="headertype" minOccurs="0" maxOccurs="1"/>
       <xs:element name="Children" type="childrentype" minOccurs="1" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="headertype">
     <xs:sequence>
-      <xs:element name="CollectionDetails" type="collectiondetailstype" minOccurs="1" maxOccurs="1"/>
-      <xs:element name="Source" type="sourcetype" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="CollectionDetails" type="collectiondetailstype" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Source" type="sourcetype" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="collectiondetailstype">
     <xs:sequence>
-      <xs:element name="Collection" minOccurs="1" maxOccurs="1">
+      <xs:element name="Collection" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:enumeration value="CIN"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="Year" type="xs:gYear" minOccurs="1" maxOccurs="1"/>
-      <xs:element name="ReferenceDate" type="xs:date" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Year" type="xs:gYear" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenceDate" type="xs:date" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="sourcetype">
     <xs:sequence>
-      <xs:element name="SourceLevel" minOccurs="1" maxOccurs="1">
+      <xs:element name="SourceLevel" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:enumeration value="L"/>
@@ -47,16 +47,16 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="SoftwareCode" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="SoftwareCode" type="xs:string" minOccurs="0" maxOccurs="1"/>
       <xs:element name="Release" type="xs:string" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="SerialNo" minOccurs="1" maxOccurs="1">
+      <xs:element name="SerialNo" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string" >
             <xs:pattern value="\d{3}\d*"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="DateTime" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="DateTime" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
 


### PR DESCRIPTION
Errors in the Header node do not affect any of the other results and are not used at all throughout the process so the scripts should continue running if there are errors there