### PR TITLE
catch blank LAchildIDs and write them to the error log

### DIFF
--- a/liiatools/datasets/cin_census/cin_cli.py
+++ b/liiatools/datasets/cin_census/cin_cli.py
@@ -112,13 +112,14 @@ def cleanfile(input, la_code, la_log_dir, output):
     )
     value_error = []
     structural_error = []
+    LAchildID_blank = []
     stream = logger.counter(
         stream,
         counter_check=lambda e: isinstance(e, events.StartElement)
         and hasattr(e, "valid"),
         value_error=value_error,
         structural_error=structural_error,
-        LAchildID_error=LAchildID_error,
+        LAchildID_blank=LAchildID_blank,
     )
 
     # Clean stream
@@ -170,6 +171,7 @@ def cleanfile(input, la_code, la_log_dir, output):
         LAchildID_error=LAchildID_error,
         field_error=field_error,
         la_log_dir=la_log_dir,
+        LAchildID_blank=LAchildID_blank
     )
 
 

--- a/liiatools/datasets/cin_census/lds_cin_clean/logger.py
+++ b/liiatools/datasets/cin_census/lds_cin_clean/logger.py
@@ -36,7 +36,7 @@ def inherit_LAchildID(stream):
 
 
 @streamfilter(check=lambda x: True)
-def counter(event, counter_check, value_error, structural_error):
+def counter(event, counter_check, value_error, structural_error, LAchildID_blank):
     """
     Count the invalid simple nodes storing their name and LAchildID data
 
@@ -44,23 +44,39 @@ def counter(event, counter_check, value_error, structural_error):
     :param counter_check: A function to identify which events to check
     :param value_error: An empty list to store the invalid element information
     :param structural_error: An empty list to store the invalid structure information
+    :param LAchildID_blank: An empty list to store the number of blank LAchildIDs
     :return: The same filtered list of event objects
     """
     if counter_check(event) and len(event.node) == 0:
-        if event.LAchildID is not None:
-            try:
+        if (
+            getattr(event, "LAchildID", None) is not None
+        ):  # In case there are errors in the <Header> node as none
+            # of these will have an LAchildID assigned
+            if hasattr(event.schema, "name"):
                 value_error.append(
                     f"LAchildID: {event.LAchildID}, Node: {event.schema.name}"
                 )
-            except AttributeError:  # Raised in case there is no event.schema.name
+            else:
                 structural_error.append(
                     f"LAchildID: {event.LAchildID}, Node: {event.tag}"
                 )
+        else:
+            LAchildID_blank.append("LAchildID")
+            if hasattr(event.schema, "name"):
+                value_error.append(f"LAchildID: blank, Node: {event.schema.name}")
+            else:
+                structural_error.append(f"LAchildID: blank, Node: {event.tag}")
     return event
 
 
 def save_errors_la(
-    input, value_error, structural_error, LAchildID_error, field_error, la_log_dir
+    input,
+    value_error,
+    structural_error,
+    LAchildID_error,
+    field_error,
+    LAchildID_blank,
+    la_log_dir,
 ):
     """
     Save the errors as a text file in the Local Authority Logs directory
@@ -70,12 +86,20 @@ def save_errors_la(
     :param value_error: A list of invalid element information
     :param structural_error: A list of invalid structure information
     :param field_error: A list of missing fields
+    :param LAchildID_error: A list of missing LAchildID information
+    :param LAchildID_blank: A count of LAchildIDs found to be blank
     :param la_log_dir: Location to save the gathered error logs
     :return: An updated list of event objects
     """
     filename = str(Path(input).resolve().stem)
     start_time = f"{datetime.now():%d-%m-%Y %Hh-%Mm-%Ss}"
-    if value_error or structural_error or field_error or LAchildID_error:
+    if (
+        value_error
+        or structural_error
+        or field_error
+        or LAchildID_error
+        or LAchildID_blank
+    ):
         with open(
             f"{Path(la_log_dir, filename)}_error_log_{start_time}.txt",
             "a",
@@ -100,6 +124,11 @@ def save_errors_la(
                 for item in structural_error:
                     f.write(item)
                     f.write("\n")
+                f.write("\n")
+            if LAchildID_blank:
+                f.write(
+                    f"Number of LAchildIDs that were found to be blank: {len(LAchildID_blank)}"
+                )
                 f.write("\n")
             if LAchildID_error:
                 LAchildID_error = list(


### PR DESCRIPTION
Initially just caught completely missing LAchildIDs i.e. no node, now it catches when that node exists but is empty