### PR TITLE
fixed error with blank cells

### DIFF
--- a/liiatools/datasets/s903/lds_ssda903_clean/logger.py
+++ b/liiatools/datasets/s903/lds_ssda903_clean/logger.py
@@ -63,7 +63,8 @@ def blank_error_check(event):
     """
     try:
         allowed_blank = event.config_dict["canbeblank"]
-        if not allowed_blank and not event.cell and event.error != "1":
+        error = getattr(event, "error", "0")
+        if not allowed_blank and not event.cell and error != "1":
             return event.from_event(event, blank_error="1")
         else:
             return event

--- a/tests/s903/test_populate.py
+++ b/tests/s903/test_populate.py
@@ -70,10 +70,14 @@ def test_create_la_child_id():
     stream = populate.create_la_child_id(
         [
             events.Cell(header="CHILD", cell="123"),
+            events.Cell(header="CHILD", cell=""),
+            events.Cell(header="CHILD", cell=None),
             events.Cell(header="NOT_CHILD", cell="456"),
         ],
         la_code="BAD",
     )
     stream = list(stream)
     assert stream[0].cell == "123_BAD"
-    assert stream[1].cell == "456"
+    assert stream[1].cell == "_BAD"
+    assert stream[2].cell == "None_BAD"
+    assert stream[3].cell == "456"


### PR DESCRIPTION
Some cells did not have an event.error as they had not be cleaned so were being missed when checking for blank errors causing dimension errors when adding rows into a table

also adding more testing to populate.create_la_child_id function