### PR TITLE
la-agg and pan-agg work still even with 0 events

### DIFF
--- a/liiatools/datasets/cin_census/cin_cli.py
+++ b/liiatools/datasets/cin_census/cin_cli.py
@@ -225,25 +225,29 @@ def la_agg(input, flat_output, analysis_output):
     factors = agg_process.filter_flatfile(
         flatfile, filter="AssessmentAuthorisationDate"
     )
-    factors = agg_process.split_factors(factors)
-    agg_process.export_factfile(analysis_output, factors)
+    if len(factors) > 0:
+        factors = agg_process.split_factors(factors)
+        agg_process.export_factfile(analysis_output, factors)
 
     # Create referral file
     ref, s17, s47 = agg_process.referral_inputs(flatfile)
-    ref_assessment = config["ref_assessment"]
-    ref_s17 = agg_process.merge_ref_s17(ref, s17, ref_assessment)
-    ref_s47 = agg_process.merge_ref_s47(ref, s47, ref_assessment)
-    ref_outs = agg_process.ref_outcomes(ref, ref_s17, ref_s47)
-    agg_process.export_reffile(analysis_output, ref_outs)
+    if len(s17) > 0 and len(s47) > 0:
+        ref_assessment = config["ref_assessment"]
+        ref_s17 = agg_process.merge_ref_s17(ref, s17, ref_assessment)
+        ref_s47 = agg_process.merge_ref_s47(ref, s47, ref_assessment)
+        ref_outs = agg_process.ref_outcomes(ref, ref_s17, ref_s47)
+        agg_process.export_reffile(analysis_output, ref_outs)
 
     # Create journey file
     icpc_cpp_days = config["icpc_cpp_days"]
     s47_cpp_days = config["s47_cpp_days"]
-    s47_outs = agg_process.journey_inputs(flatfile, icpc_cpp_days, s47_cpp_days)
-    s47_day_limit = config["s47_day_limit"]
-    icpc_day_limit = config["icpc_day_limit"]
-    s47_journey = agg_process.s47_paths(s47_outs, s47_day_limit, icpc_day_limit)
-    agg_process.export_journeyfile(analysis_output, s47_journey)
+    s47_j, cpp = agg_process.journey_inputs(flatfile)
+    if len(s47_j) > 0 and len(cpp) > 0:
+        s47_outs = agg_process.journey_merge(s47_j, cpp, icpc_cpp_days, s47_cpp_days)
+        s47_day_limit = config["s47_day_limit"]
+        icpc_day_limit = config["icpc_day_limit"]
+        s47_journey = agg_process.s47_paths(s47_outs, s47_day_limit, icpc_day_limit)
+        agg_process.export_journeyfile(analysis_output, s47_journey)
 
 
 @cin_census.command()
@@ -300,22 +304,26 @@ def pan_agg(input, la_code, flat_output, analysis_output):
     factors = pan_process.filter_flatfile(
         flatfile, filter="AssessmentAuthorisationDate"
     )
-    factors = pan_process.split_factors(factors)
-    pan_process.export_factfile(analysis_output, factors)
+    if len(factors) > 0:
+        factors = pan_process.split_factors(factors)
+        pan_process.export_factfile(analysis_output, factors)
 
     # Create referral file
     ref, s17, s47 = pan_process.referral_inputs(flatfile)
-    ref_assessment = config["ref_assessment"]
-    ref_s17 = pan_process.merge_ref_s17(ref, s17, ref_assessment)
-    ref_s47 = pan_process.merge_ref_s47(ref, s47, ref_assessment)
-    ref_outs = pan_process.ref_outcomes(ref, ref_s17, ref_s47)
-    pan_process.export_reffile(analysis_output, ref_outs)
+    if len(s17) > 0 and len(s47) > 0:
+        ref_assessment = config["ref_assessment"]
+        ref_s17 = pan_process.merge_ref_s17(ref, s17, ref_assessment)
+        ref_s47 = pan_process.merge_ref_s47(ref, s47, ref_assessment)
+        ref_outs = pan_process.ref_outcomes(ref, ref_s17, ref_s47)
+        pan_process.export_reffile(analysis_output, ref_outs)
 
     # Create journey file
     icpc_cpp_days = config["icpc_cpp_days"]
     s47_cpp_days = config["s47_cpp_days"]
-    s47_outs = pan_process.journey_inputs(flatfile, icpc_cpp_days, s47_cpp_days)
-    s47_day_limit = config["s47_day_limit"]
-    icpc_day_limit = config["icpc_day_limit"]
-    s47_journey = pan_process.s47_paths(s47_outs, s47_day_limit, icpc_day_limit)
-    pan_process.export_journeyfile(analysis_output, s47_journey)
+    s47_j, cpp = pan_process.journey_inputs(flatfile)
+    if len(s47_j) > 0 and len(cpp) > 0:
+        s47_outs = pan_process.journey_merge(s47_j, cpp, icpc_cpp_days, s47_cpp_days)
+        s47_day_limit = config["s47_day_limit"]
+        icpc_day_limit = config["icpc_day_limit"]
+        s47_journey = pan_process.s47_paths(s47_outs, s47_day_limit, icpc_day_limit)
+        pan_process.export_journeyfile(analysis_output, s47_journey)

--- a/liiatools/datasets/cin_census/lds_cin_la_agg/process.py
+++ b/liiatools/datasets/cin_census/lds_cin_la_agg/process.py
@@ -109,7 +109,7 @@ def _time_between_date_series(later_date_series, earlier_date_series, years=0, d
 
     elif years == 1:
         years_series = (days_series / 365).apply(np.floor)
-        years_series = years_series.astype(int)
+        years_series = years_series.astype('Int32')
         return years_series
 
 
@@ -213,13 +213,20 @@ def export_reffile(analysis_output, ref_outs):
     ref_outs.to_csv(output_path, index=False)
 
 
-def journey_inputs(flatfile, icpc_cpp_days, s47_cpp_days):
+def journey_inputs(flatfile):
     """
-    Creates the input for the journey analysis file
+    Creates inputs for the journey analysis file
     """
     # Create inputs from flatfile and merge them
     s47_j = filter_flatfile(flatfile, "S47ActualStartDate")
     cpp = filter_flatfile(flatfile, "CPPstartDate")
+    return s47_j, cpp
+
+
+def journey_merge(s47_j, cpp, icpc_cpp_days, s47_cpp_days):
+    """
+    Merges inputs to produce outcomes file
+    """
     s47_cpp = s47_j.merge(
         cpp[["LAchildID", "CPPstartDate"]], how="left", on="LAchildID"
     )

--- a/liiatools/datasets/cin_census/lds_cin_pan_agg/process.py
+++ b/liiatools/datasets/cin_census/lds_cin_pan_agg/process.py
@@ -94,7 +94,7 @@ def _time_between_date_series(later_date_series, earlier_date_series, years=0, d
 
     elif years == 1:
         years_series = (days_series / 365).apply(np.floor)
-        years_series = years_series.astype(int)
+        years_series = years_series.astype('Int32')
         return years_series
 
 
@@ -198,13 +198,20 @@ def export_reffile(analysis_output, ref_outs):
     ref_outs.to_csv(output_path, index=False)
 
 
-def journey_inputs(flatfile, icpc_cpp_days, s47_cpp_days):
+def journey_inputs(flatfile):
     """
     Creates the input for the journey analysis file
     """
     # Create inputs from flatfile and merge them
     s47_j = filter_flatfile(flatfile, "S47ActualStartDate")
     cpp = filter_flatfile(flatfile, "CPPstartDate")
+    return s47_j, cpp
+
+
+def journey_merge(s47_j, cpp, icpc_cpp_days, s47_cpp_days):
+    """
+    Merges inputs to produce outcomes file
+    """
     s47_cpp = s47_j.merge(
         cpp[["LAchildID", "CPPstartDate"]], how="left", on="LAchildID"
     )


### PR DESCRIPTION
This PR is to fix an issue that is unlikely to occur with real data. When files were processed using la-agg and pan-agg that had no assessment events, the scripts would fail as empty dataframes would be produced that could not be manipulated in the way the code was designed.

I've changed this so that if these dataframes are empty, sections of the code will be skipped. This is achieved by using some
if len(df) > 0:
before sections of code.

This means that some analytical outputs won't be produced, but there's nothing to show in them in any case if this issue occurs!