### PR TITLE
stop erroneous errors by consuming the whole stream

### DIFF
--- a/liiatools/datasets/cin_census/cin_cli.py
+++ b/liiatools/datasets/cin_census/cin_cli.py
@@ -95,6 +95,7 @@ def cleanfile(input, la_code, la_log_dir, output):
         la_log_dir=la_log_dir,
     )
     stream = dom_parse(input)
+    stream = list(stream)
 
     # Configure stream
     config = clean_config.Config()


### PR DESCRIPTION
Erroneous errors would occur with .xml files over ~900 lines long. This was likely to do with a race condition between consuming the stream and validating the stream. Now it is consumed completely before any validation.