### PR TITLE
903 dedup extended to  all file types

### DIFF
--- a/liiatools/datasets/s903/lds_ssda903_la_agg/process.py
+++ b/liiatools/datasets/s903/lds_ssda903_la_agg/process.py
@@ -52,8 +52,7 @@ def deduplicate(s903_df, table_name, sort_order, dedup):
     s903_df = s903_df.sort_values(
         sort_order[table_name], ascending=False, ignore_index=True
     )
-    if table_name in dedup.keys():
-        s903_df = s903_df.drop_duplicates(subset=dedup[table_name], keep="first")
+    s903_df = s903_df.drop_duplicates(subset=dedup[table_name], keep="first")
     return s903_df
 
 

--- a/liiatools/spec/s903/la-agg.yml
+++ b/liiatools/spec/s903/la-agg.yml
@@ -182,3 +182,34 @@ dedup:
     PrevPerm:
         - CHILD
         - DATE_PERM
+    OC2:
+        - CHILD
+        - DOB
+        - SDQ_SCORE
+        - SDQ_REASON
+        - CONVICTED
+        - HEALTH_CHECK
+        - IMMUNISATIONS
+        - TEETH_CHECK
+        - HEALTH_ASSESSMENT
+        - SUBSTANCE_MISUSE
+        - INTERVENTION_RECEIVED
+        - INTERVENTION_OFFERED
+        - LA
+        - YEAR
+    OC3:
+        - CHILD
+        - DOB
+        - IN_TOUCH
+        - ACTIV
+        - ACCOM
+        - LA
+        - YEAR
+    Missing:
+        - CHILD
+        - DOB
+        - MISSING
+        - MIS_START
+        - MIS_END
+        - LA
+        - YEAR


### PR DESCRIPTION
Previously, de-duplication of records in 903 tables was only running for seven of the ten file types. This was because these are the files where duplicates are expected from year to year.

However, I had not considered the possibility of the same file being processed twice on the platform. Before these changes, that would have led to a doubling of data in the aggregated outputs.

With this change, de-duplication on these files is run for all fields in the files, meaning that if the same file was run twice, none of the records from the second run would enter aggregate outputs.