### PR TITLE
903 0C2 fields mandatory status

### DIFF
--- a/liiatools/spec/s903/config.yml
+++ b/liiatools/spec/s903/config.yml
@@ -305,42 +305,42 @@ column_map:
        category:
        - code: "0"
        - code: "1"
-       canbeblank: no
+       canbeblank: yes
       HEALTH_CHECK:
        category:
        - code: "0"
        - code: "1"
-       canbeblank: no
+       canbeblank: yes
       IMMUNISATIONS:
        category:
        - code: "0"
        - code: "1"
-       canbeblank: no
+       canbeblank: yes
       TEETH_CHECK:
        category:
        - code: "0"
        - code: "1"
-       canbeblank: no
+       canbeblank: yes
       HEALTH_ASSESSMENT:
        category:
        - code: "0"
        - code: "1"
-       canbeblank: no
+       canbeblank: yes
       SUBSTANCE_MISUSE:
        category:
        - code: "0"
        - code: "1"
-       canbeblank: no
+       canbeblank: yes
       INTERVENTION_RECEIVED:
        category:
        - code: "0"
        - code: "1"
-       canbeblank: no
+       canbeblank: yes
       INTERVENTION_OFFERED:
        category:
        - code: "0"
        - code: "1"
-       canbeblank: no
+       canbeblank: yes
     OC3:
       CHILD:
        string: "alphanumeric"


### PR DESCRIPTION
Very small change.

A few fields in the OC2 table of the 903 returns were marked as mandatory when they are, in fact, optional.

The schema has been updated to reflect this.