### PR TITLE
add_year_column raise Exception removed

### DIFF
--- a/liiatools/datasets/s903/lds_ssda903_clean/populate.py
+++ b/liiatools/datasets/s903/lds_ssda903_clean/populate.py
@@ -25,10 +25,6 @@ def add_year_column(stream, input, la_log_dir):
                 yield event.from_event(event, year=year)
             except AttributeError:
                 common.save_year_error(input, la_log_dir)
-                raise Exception(
-                    f"{event.filename} was not processed as the filename did not contain a year, "
-                    f"this error has been sent to the LA to be fixed"
-                )
         elif isinstance(event, events.EndTable):
             yield event
             year = None


### PR DESCRIPTION
When the year in the filename was invalid or missing, the code to raise an Exception within the add_year_column function was creating an Exception in the stack trace.

This piece of code has been removed so that, when this happens:
- the error log is created for the LA
- processing of the current file ends
- no output file is produced

This should, I believe, allow the a process that iterates over lots of files to simply move onto the next file without ending altogether.