### PR TITLE
strip whitespace from child_id

### DIFF
--- a/liiatools/datasets/s903/lds_ssda903_clean/populate.py
+++ b/liiatools/datasets/s903/lds_ssda903_clean/populate.py
@@ -46,13 +46,12 @@ def create_la_child_id(event, la_code):
     """
     if isinstance(event.cell, str) and event.cell[-2:] == ".0":
         child_id = int(float(event.cell))
+    elif isinstance(event.cell, str):
+        child_id = event.cell.strip()
     elif isinstance(event.cell, float):
         child_id = int(event.cell)
     else:
-        try:
-            child_id = event.cell.strip()
-        except AttributeError:
-            child_id = event.cell
+        child_id = event.cell
 
     la_child_id = f"{child_id}_{la_code}"
     yield event.from_event(event, cell=la_child_id)

--- a/liiatools/datasets/s903/lds_ssda903_clean/populate.py
+++ b/liiatools/datasets/s903/lds_ssda903_clean/populate.py
@@ -49,7 +49,10 @@ def create_la_child_id(event, la_code):
     elif isinstance(event.cell, float):
         child_id = int(event.cell)
     else:
-        child_id = event.cell
+        try:
+            child_id = event.cell.strip()
+        except AttributeError:
+            child_id = event.cell
 
     la_child_id = f"{child_id}_{la_code}"
     yield event.from_event(event, cell=la_child_id)

--- a/tests/s903/test_populate.py
+++ b/tests/s903/test_populate.py
@@ -69,7 +69,7 @@ def test_add_year_column():
 def test_create_la_child_id():
     stream = populate.create_la_child_id(
         [
-            events.Cell(header="CHILD", cell="123"),
+            events.Cell(header="CHILD", cell=" 123"),
             events.Cell(header="CHILD", cell=""),
             events.Cell(header="CHILD", cell=None),
             events.Cell(header="NOT_CHILD", cell="456"),


### PR DESCRIPTION
whitespace around child_id was causing issues with the child_ids that had whitespace in one year but not the other, with the code believing them to be different children. Now whitespace is striped